### PR TITLE
GL/glew.h -> glew.h

### DIFF
--- a/src/mfgd.c
+++ b/src/mfgd.c
@@ -1,4 +1,4 @@
-#include <GL/glew.h>
+#include <glew.h>
 #include <stdint.h>
 #include <SDL.h>
 

--- a/src/renderer.c
+++ b/src/renderer.c
@@ -1,6 +1,6 @@
 #include "renderer.h"
 #include "utils.h"
-#include <GL/glew.h>
+#include <glew.h>
 
 app* application = NULL;
 

--- a/src/shader.c
+++ b/src/shader.c
@@ -1,4 +1,4 @@
-#include <GL/glew.h>
+#include <glew.h>
 #include <stdlib.h>
 #include <assert.h>
 


### PR DESCRIPTION
On my machine with brew-built `glew` 1.10.0 the header is `glew.h` not `GL/glew.h` as per the paths generated in the build.
